### PR TITLE
refactor(quizzes): implementado deep nested deletion nos quizzes, categorias e alternativas

### DIFF
--- a/src/database/schemas/questionSchema.go
+++ b/src/database/schemas/questionSchema.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type Question struct {
@@ -12,7 +13,7 @@ type Question struct {
 	Content   string          `json:"content,omitempty" gorm:"not null"`
 	QuizID    string          `json:"quiz_id,omitempty" gorm:"not null"`
 	Quiz      *Quiz           `json:"quiz,omitempty"`
-	Choices   []Choice        `json:"choices,omitempty" gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	Choices   []Choice        `json:"choices,omitempty"`
 	CreatedAt *time.Time      `json:"created_at,omitempty"`
 	UpdatedAt *time.Time      `json:"updated_at,omitempty"`
 	DeletedAt *gorm.DeletedAt `json:"deleted_at,omitempty" gorm:"index"`
@@ -22,5 +23,10 @@ func (q *Question) BeforeCreate(tx *gorm.DB) (err error) {
 	if q.ID == "" {
 		q.ID = uuid.New().String()
 	}
+	return
+}
+
+func (q *Question) AfterDelete(tx *gorm.DB) (err error) {
+	tx.Clauses(clause.Returning{}).Where("question_id = ?", q.ID).Delete(&Choice{})
 	return
 }

--- a/src/database/schemas/quizSchema.go
+++ b/src/database/schemas/quizSchema.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type Quiz struct {
@@ -14,7 +15,7 @@ type Quiz struct {
 	Category   *Category       `json:"category,omitempty"`
 	CreatedBy  string          `json:"created_by,omitempty"`
 	User       *User           `json:"user,omitempty" gorm:"foreignKey:CreatedBy"`
-	Questions  []Question      `json:"questions,omitempty" gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	Questions  []Question      `json:"questions,omitempty"`
 	CreatedAt  *time.Time      `json:"created_at,omitempty"`
 	UpdatedAt  *time.Time      `json:"updated_at,omitempty"`
 	DeletedAt  *gorm.DeletedAt `json:"deleted_at,omitempty" gorm:"index"`
@@ -24,5 +25,10 @@ func (q *Quiz) BeforeCreate(tx *gorm.DB) (err error) {
 	if q.ID == "" {
 		q.ID = uuid.New().String()
 	}
+	return
+}
+
+func (q *Quiz) AfterDelete(tx *gorm.DB) (err error) {
+	tx.Clauses(clause.Returning{}).Where("quiz_id = ?", q.ID).Delete(&Question{})
 	return
 }

--- a/src/handlers/quizzesHandlers.go
+++ b/src/handlers/quizzesHandlers.go
@@ -440,7 +440,7 @@ func DeleteQuiz(c *gin.Context, db *gorm.DB) {
 		return
 	}
 
-	_, err = gorm.G[schemas.Quiz](db).Where("id = ?", quizUuid).Delete(c)
+	err = db.Where("id = ?", quizUuid.String()).Delete(&schemas.Quiz{ID: quizUuid.String()}).Error
 
 	if err != nil {
 		log.Printf("Error deleting quiz: %v", err)


### PR DESCRIPTION
This pull request refactors the database schema for quizzes and questions, improves cascading deletion logic, and adds validation when creating quizzes. The most important changes include moving cascade deletion logic from GORM struct tags to explicit `AfterDelete` hooks, ensuring related entities are properly deleted, and adding a check to verify the existence of a category before creating a quiz.

**Database schema and cascade deletion improvements:**

* Removed GORM cascade constraint tags from the `Choices` field in `Question` and the `Questions` field in `Quiz`, replacing them with explicit `AfterDelete` hooks to handle cascading deletions for related entities. (`src/database/schemas/questionSchema.go`, `src/database/schemas/quizSchema.go`) [[1]](diffhunk://#diff-1f21f6457a8c4da1af49295390b559a9a7f756a2846871db31a530bd77b8a84dR8-R16) [[2]](diffhunk://#diff-c550653c1ac3fe9ebf929ade9b827e583eae6acac05d3db2b3b697e0760d2114L17-R18)
* Added an `AfterDelete` hook to the `Question` model to delete all associated `Choice` records when a question is deleted. (`src/database/schemas/questionSchema.go`)
* Added an `AfterDelete` hook to the `Quiz` model to delete all associated `Question` records when a quiz is deleted. (`src/database/schemas/quizSchema.go`)

**Handler improvements:**

* Added a check in the `CreateQuiz` handler to verify that the provided category exists before creating a quiz, returning appropriate error responses if not found or if an error occurs. (`src/handlers/quizzesHandlers.go`)
* Updated the `DeleteQuiz` handler to use a direct GORM delete operation for quizzes by ID, aligning with the new cascade deletion logic. (`src/handlers/quizzesHandlers.go`)