### PR TITLE
fix(homepage): fixed best quizzes likes count and increased access token duration

### DIFF
--- a/src/auth/auth.go
+++ b/src/auth/auth.go
@@ -28,7 +28,7 @@ func IssueTokens(userID string) (*Tokens, error) {
 		UserID:   userID,
 		JTIAcc:   uuid.NewString(),
 		JTIRef:   uuid.NewString(),
-		ExpAcc:   now.Add(15 * time.Minute),
+		ExpAcc:   now.Add(2 * time.Hour),
 		ExpRef:   now.Add(7 * 24 * time.Hour),
 		Issuer:   "intelliquiz-app",
 		Audience: "intelliquiz-client",

--- a/src/handlers/homePageHandlers.go
+++ b/src/handlers/homePageHandlers.go
@@ -199,7 +199,7 @@ func HomePage(c *gin.Context, db *gorm.DB) {
 		Joins("LEFT JOIN games AS games_last_month ON games_last_month.quiz_id = quizzes.id AND games_last_month.created_at >= ?", time.Now().AddDate(0, -1, 0)).
 		Joins("LEFT JOIN quiz_user_likes AS ql_all_time ON ql_all_time.quiz_id = quizzes.id").
 		Joins("LEFT JOIN quiz_user_likes AS ql_last_month ON ql_last_month.quiz_id = quizzes.id AND ql_last_month.created_at >= ?", time.Now().AddDate(0, -1, 0)).
-		Select("quizzes.*, COUNT(ql_all_time.user_id) AS likes, (COUNT(games_all_time.id) * 0.05) + (COUNT(games_last_month.id) * 0.3) + (COUNT(ql_all_time.user_id) * 0.15) + (COUNT(ql_last_month.user_id) * 0.5) AS score").
+		Select("quizzes.*, COUNT(DISTINCT ql_all_time.user_id) AS likes, (COUNT(DISTINCT games_all_time.id) * 0.05) + (COUNT(DISTINCT games_last_month.id) * 0.3) + (COUNT(DISTINCT ql_all_time.user_id) * 0.15) + (COUNT(DISTINCT ql_last_month.user_id) * 0.5) AS score").
 		Group("quizzes.id").
 		Order("score DESC").
 		Limit(21).


### PR DESCRIPTION
This pull request introduces two key improvements: it extends the access token lifetime for user authentication and refines the quiz scoring logic on the home page to more accurately count unique users and games.

**Authentication updates:**

* Increased the access token expiration time from 15 minutes to 2 hours in the `IssueTokens` function in `src/auth/auth.go`, allowing users to stay logged in longer before needing to refresh their token.

**Quiz scoring and statistics improvements:**

* Updated the SQL query in the `HomePage` handler in `src/handlers/homePageHandlers.go` to use `COUNT(DISTINCT ...)` for likes and games, ensuring that each user and game is counted only once in popularity and scoring calculations.